### PR TITLE
use IS_PRODUCTION for Analytics

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,7 +16,7 @@ import * as gtag from "../utils/gtag";
 const App: FC<AppProps> = ({ Component, pageProps }) => {
   const router = useRouter();
 
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.IS_PRODUCTION) {
     useEffect(() => {
       const handleRouteChange = (url: URL) => {
         gtag.pageview(url);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -102,7 +102,7 @@ class MyDocument extends Document {
             href="https://cloud.typography.com/6522872/7140832/css/fonts.css"
             rel="stylesheet"
           />
-          {process.env.NODE_ENV === "production" && (
+          {process.env.IS_PRODUCTION && (
             <>
               {/* Global Site Tag (gtag.js) - Google Analytics */}
               <script


### PR DESCRIPTION
Previously I was using `NODE_ENV === "production"` for checking for analytics.

This change uses a "hack" around how NextJS environment variables work to determine if it's _really_ in production, by creating an `IS_PRODUCTION` environment variable that's only applied in the `production` environment.

`NODE_ENV` is `production` for all Vercel deploys for preview and production, so it's a less accurate variable to check.

![image](https://user-images.githubusercontent.com/1024544/111906177-93de6b80-8a0c-11eb-8b88-86e7973e65ad.png)
