### PR TITLE
Chg fonts

### DIFF
--- a/src/components/SiteHeader/index.tsx
+++ b/src/components/SiteHeader/index.tsx
@@ -116,7 +116,6 @@ export const SiteHeader = () => {
                       },
                     },
                     [`&:hover ${BlobBox}`]: {
-                      // md:group-hover:translate-x-2 md:group-hover:w-10 md:group-hover:-ml-11 transition-all
                       ml: "-$8",
                       transform: "scale(.7) translateX(0.5rem)",
                       [`.${darkTheme} &`]: {
@@ -151,7 +150,7 @@ export const SiteHeader = () => {
                       },
                     }}
                   >
-                    <Text size={"3xl"}>c</Text>
+                    <Text size={{ "@initial": "3xl", "@bp1": "4xl" }}>c</Text>
                     <HoverShowText
                       css={{
                         display: "block",
@@ -159,11 +158,11 @@ export const SiteHeader = () => {
                           display: "none",
                         },
                       }}
-                      size={"3xl"}
+                      size={{ "@initial": "3xl", "@bp1": "4xl" }}
                     >
                       hase
                     </HoverShowText>
-                    <Text size={"3xl"}> a</Text>
+                    <Text size={{ "@initial": "3xl", "@bp1": "4xl" }}> a</Text>
                     <HoverShowText
                       css={{
                         display: "block",
@@ -171,7 +170,7 @@ export const SiteHeader = () => {
                           display: "none",
                         },
                       }}
-                      size={"3xl"}
+                      size={{ "@initial": "3xl", "@bp1": "4xl" }}
                     >
                       dams
                     </HoverShowText>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,6 +11,16 @@ class MyDocument extends Document {
             href="https://cloud.typography.com/6522872/7140832/css/fonts.css"
             rel="stylesheet"
           />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="true"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@100;400;700&family=JetBrains+Mono:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap"
+            rel="stylesheet"
+          />
           {process.env.IS_PRODUCTION && (
             <>
               {/* Global Site Tag (gtag.js) - Google Analytics */}

--- a/src/styles/stitches.config.ts
+++ b/src/styles/stitches.config.ts
@@ -15,9 +15,9 @@ export const stitchesConfig = createStitches({
       primary: "$blue400",
     },
     fonts: {
-      sans: ['"Ringside Regular SSm A"', "Helvetica"].join(","),
+      sans: ["Inter", "Helvetica"].join(","),
       mono:
-        "ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace",
+        "'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace",
     },
     fontSizes: {
       sm: "0.75rem",


### PR DESCRIPTION
- use inter and JetBrains Mono (Ringside Hoeffler subscription lapses soon)
- update ca site header to work with new font